### PR TITLE
Refactor HTML/CSS and add dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,58 +1,65 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="de">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" href="img/icon.png" type="image/png">
-    <meta name="description" content="QuestDo gibt Dir und Deinen Freunden kleine Aufgaben (Sidequests) zum Erledigen. Mit jeder erledigten Quest erhält man XP, um im Leaderboard aufzusteigen.">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="img/icon.png" type="image/png" />
+    <meta
+      name="description"
+      content="QuestDo gibt Dir und Deinen Freunden kleine Aufgaben (Sidequests) zum Erledigen. Mit jeder erledigten Quest erhält man XP, um im Leaderboard aufzusteigen."
+    />
     <title>QuestDo</title>
 
     <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 0;
-            padding: 0;
-            background-color: #ECEFF1;
-        }
+      * {
+        box-sizing: border-box;
+      }
 
-        header {
-            background-color: #191970;
-            color: #ECEFF1;
-            padding: 1em;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
+      body {
+        font-family: Arial, sans-serif;
+        margin: 0;
+        padding: 0;
+        background-color: #eceff1;
+      }
 
-            box-shadow: 0 2px 10px rgba(0,0,0,0.2);
-        }
+      header {
+        background-color: #191970;
+        color: #eceff1;
+        padding: 1em;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
 
-        nav ul {
-            list-style: none;
-            margin: 0;
-            padding: 0;
-            display: flex;
-            gap: 20px;
-        }
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+      }
 
-        nav ul li a {
-            color: #ECEFF1;
-            text-decoration: none;
-        }
+      nav ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        gap: 20px;
+      }
 
-        footer {
-            background-color: #191970;
-            color: #ECEFF1;
-            text-align: center;
-            padding: 1em;
-            width: 100%;
-        }
+      nav ul li a {
+        color: #eceff1;
+        text-decoration: none;
+      }
 
-        footer p {
-            margin: 0;
-        }
+      footer {
+        background-color: #191970;
+        color: #eceff1;
+        text-align: center;
+        padding: 1em;
+        width: 100%;
+      }
 
-        main {
-        width: 90%;
+      footer p {
+        margin: 0;
+      }
+
+      main {
+        width: 80%;
         max-width: 800px;
         margin: 50px auto;
         padding: 20px;
@@ -63,159 +70,212 @@
         align-items: center;
         text-align: center;
 
-        background: linear-gradient(rgba(25,25,112,0.8), rgba(25,25,112,0.8)),
-                url('img/background.png');
+        background:
+          linear-gradient(rgba(25, 25, 112, 0.8), rgba(25, 25, 112, 0.8)),
+          url("img/background.png");
         background-size: cover;
         background-position: center;
-        }
+      }
 
+      .btn {
+        background-color: #eceff1;
+        color: #191970;
+        border: none;
+        padding: 10px 20px;
+        font-size: 20px;
+        border-radius: 5px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+      }
+
+      .btn:hover {
+        transform: scale(1.05);
+        background-color: #ffffff;
+      }
+
+      main p {
+        font-size: 18px;
+        color: #eceff1;
+      }
+
+      main h2 {
+        color: #eceff1;
+      }
+
+      main ul {
+        text-align: left;
+        font-size: 18px;
+        color: #eceff1;
+      }
+
+      section {
+        margin-top: 40px;
+      }
+
+      .credits {
+        text-align: center;
+        padding: 40px 20px;
+      }
+
+      .contributors {
+        display: flex;
+        justify-content: center;
+        gap: 30px;
+        flex-wrap: wrap;
+      }
+
+      .contributor {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-decoration: none;
+        color: #eceff1;
+        gap: 8px;
+      }
+
+      .contributor img {
+        width: 50px;
+        height: 50px;
+        border-radius: 50%;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background-color: #191970;
+        }
+        header,
+        footer {
+          background-color: #eceff1;
+          color: #191970;
+        }
+        nav ul li a {
+          color: #191970;
+        }
+        main {
+          background-color: #eceff1;
+          color: #191970;
+          background:
+            linear-gradient(rgba(236, 239, 241, 0.8), rgba(236, 239, 241, 0.8)),
+            url("img/background.png");
+        }
         .btn {
-            background-color: #ECEFF1;
-            color: #191970;
-            border: none;
-            padding: 10px 20px;
-            font-size: 20px;
-            border-radius: 5px;
-            cursor: pointer;
-            transition: all 0.2s ease;
+          background-color: #191970;
+          color: #eceff1;
         }
-
         .btn:hover {
-            transform: scale(1.05);
-            background-color: #ffffff;
+          background-color: #1c1cd7;
         }
-
-        main p {
-            font-size: 18px;
-            color: #ECEFF1;
-        }
-
-        main h2 {
-            color: #ECEFF1;
-        }
-
+        main p,
+        main h2,
         main ul {
-            text-align: left;
-            font-size: 18px;
-            color: #ECEFF1;
+          color: #191970;
         }
-
-        section {
-            margin-top: 40px;
+        .contributor {
+          color: #191970;
         }
-
-
-
-        .credits {
-  text-align: center;
-  padding: 40px 20px;
-}
-
-.contributors {
-  display: flex;
-  justify-content: center;
-  gap: 30px;
-  flex-wrap: wrap;
-}
-
-.contributor {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-decoration: none;
-  color: white;
-  gap: 8px;
-}
-
-.contributor img {
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-}
-
-
+      }
     </style>
 
     <script>
-        // Hier JavaScript rein. (@Maxel8)
+      // Hier JavaScript rein. (@Maxel8)
     </script>
-</head>
-<body>
-
+  </head>
+  <body>
     <header>
-        <h1>QuestDo</h1>
-        <nav>
-            <ul>
-                <li><a href="login.html">Login</a></li>
-                <li><a href="#">Über uns</a></li>
-                <li><a href="https://github.com/Maxel8/QuestDo">GitHub</a></li>
-            </ul>
-        </nav>
+      <h1>QuestDo</h1>
+      <nav>
+        <ul>
+          <li><a href="login.html">Login</a></li>
+          <li><a href="#">Über uns</a></li>
+          <li><a href="https://github.com/Maxel8/QuestDo">GitHub</a></li>
+        </ul>
+      </nav>
     </header>
 
     <main>
-        <section>
+      <section>
         <h2>Über QuestDo</h2>
-        <p>QuestDo gibt Dir und Deinen Freunden kleine Aufgaben (Sidequests) zum Erledigen. Mit jeder erledigten Quest erhält man XP, um im Leaderboard aufzusteigen.</p>
+        <p>
+          QuestDo gibt Dir und Deinen Freunden kleine Aufgaben (Sidequests) zum
+          Erledigen. Mit jeder erledigten Quest erhält man XP, um im Leaderboard
+          aufzusteigen.
+        </p>
 
         <a href="login.html"><button class="btn">Login</button></a>
-        </section>
+      </section>
 
-        <section>
+      <section>
         <h2>Mitwirken</h2>
-        <p>Du hast nicht nur an der Nutzung von QuestDo Interesse, sondern willst aktiv helfen, dass Projekt weiterzuentwickeln? Dann schau in dem GitHub Repository vorbei.</p>
+        <p>
+          Du hast nicht nur an der Nutzung von QuestDo Interesse, sondern willst
+          aktiv helfen, dass Projekt weiterzuentwickeln? Dann schau in dem
+          GitHub Repository vorbei.
+        </p>
         <p>Möglichkeiten zur Unterstützung:</p>
-       <ul>
-            <li>💻 Code verbessern</li>
-            <li>✨ neue Features entwickeln</li>
-            <li>🐛 Fehler melden</li>
-            <li>📜 Quests vorschlagen</li>
+        <ul>
+          <li>💻 Code verbessern</li>
+          <li>✨ neue Features entwickeln</li>
+          <li>🐛 Fehler melden</li>
+          <li>📜 Quests vorschlagen</li>
         </ul>
-        <p>Weitere Möglichkeiten sind in Arbeit (wie Übersetzungen), außerdem sind wir auch für Deine zusätzlichen Ideen offen.</p>
-        <a href="https://github.com/Maxel8/QuestDo"><button class="btn" >GitHub</button></a>
-        </section>
+        <p>
+          Weitere Möglichkeiten sind in Arbeit (wie Übersetzungen), außerdem
+          sind wir auch für Deine zusätzlichen Ideen offen.
+        </p>
+        <a href="https://github.com/Maxel8/QuestDo"
+          ><button class="btn">GitHub</button></a
+        >
+      </section>
 
-        <section class="credits">
-            <h2>Danksagungen</h2>
+      <section class="credits">
+        <h2>Danksagungen</h2>
 
-            <div class="contributors">
-    
-            <a href="https://github.com/Maxel8" target="_blank" class="contributor">
-                <img src="https://github.com/Maxel8.png" />
-                <span>Maxel8</span>
-                <small>Projektleiter</small>
-            </a>
+        <div class="contributors">
+          <a
+            href="https://github.com/Maxel8"
+            target="_blank"
+            class="contributor"
+          >
+            <img src="https://github.com/Maxel8.png" />
+            <span>Maxel8</span>
+            <small>Projektleiter</small>
+          </a>
 
-            <a href="https://github.com/ChlodwigRG" target="_blank" class="contributor">
-                <img src="https://github.com/ChlodwigRG.png" />
-                <span>ChlodwigRG</span>
-                <small>Mitwirkender</small>
-            </a>
+          <a
+            href="https://github.com/ChlodwigRG"
+            target="_blank"
+            class="contributor"
+          >
+            <img src="https://github.com/ChlodwigRG.png" />
+            <span>ChlodwigRG</span>
+            <small>Mitwirkender</small>
+          </a>
 
-            <a href="https://github.com/wclawy" target="_blank" class="contributor">
-                <img src="https://github.com/wclawy.png" />
-                <span>wclawy</span>
-                <small>Mitwirkender</small>
-            </a>
+          <a
+            href="https://github.com/wclawy"
+            target="_blank"
+            class="contributor"
+          >
+            <img src="https://github.com/wclawy.png" />
+            <span>wclawy</span>
+            <small>Mitwirkender</small>
+          </a>
 
-            <a target="_blank" class="contributor">
-                <img src="img/profile.png" />
-                <span>Tino</span>
-                <small>Quester</small>
-            </a>
-
-
-            </div>
-        </section>
-
+          <a target="_blank" class="contributor">
+            <img src="img/profile.png" />
+            <span>Tino</span>
+            <small>Quester</small>
+          </a>
+        </div>
+      </section>
     </main>
-    
+
     <footer>
-        <p>&copy; 2026 QuestDo. Alle Rechte vorbehalten.</p>
+      <p>&copy; 2026 QuestDo. Alle Rechte vorbehalten.</p>
     </footer>
 
     <script>
-        // Hier JavaScript rein. (@Maxel8)
+      // Hier JavaScript rein. (@Maxel8)
     </script>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
Clean up and refactor index.html: normalize DOCTYPE and tag formatting, make meta/link tags self-closing, and standardize indentation. Consolidate and modernize CSS (add box-sizing, unify color values, adjust main width to 80%), introduce reusable .btn styles and contributor layout, and add a prefers-color-scheme media query for dark-mode styling. Minor markup/whitespace improvements only; no content changes to copy or links.